### PR TITLE
fix: Supporting post install script on Windows

### DIFF
--- a/apps/example-app/package.json
+++ b/apps/example-app/package.json
@@ -7,7 +7,7 @@
     "@babel/plugin-transform-react-jsx": "^7.14.9",
     "@capacitor/android": "^4.7.3",
     "@capacitor/app": "4.0.1",
-    "@capacitor/background-runner": "^4.0.0-rc.1",
+    "@capacitor/background-runner": "^1.0.0-rc.1",
     "@capacitor/core": "^4.7.3",
     "@capacitor/haptics": "4.1.0",
     "@capacitor/ios": "^4.7.3",

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -43,7 +43,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "postinstall": "mkdir -p $INIT_CWD/android/app/libs/ && cp -f android/src/main/libs/android-js-engine-release.aar $INIT_CWD/android/app/libs/"
+    "postinstall": "node ./scripts/install_libs.js"
   },
   "devDependencies": {
     "@capacitor/android": "^5.2.1",

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -11,6 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
+    "scripts/install_libs.js",
     "CapacitorBackgroundRunner.podspec"
   ],
   "author": "Ionic Team",

--- a/packages/capacitor-plugin/scripts/install_libs.js
+++ b/packages/capacitor-plugin/scripts/install_libs.js
@@ -9,7 +9,7 @@ if (!workingDir) {
 }
 
 if (!fs.existsSync(path.join(workingDir, "android"))) {
-    throw new Error("cannot install android-js-engine library, not in correct parent directory.");
+    throw new Error("cannot install android-js-engine library: @capacitor/android not installed, or in wrong parent directory.");
 }
 
 const releaseAARPath = path.join("android/src/main/libs/android-js-engine-release.aar");

--- a/packages/capacitor-plugin/scripts/install_libs.js
+++ b/packages/capacitor-plugin/scripts/install_libs.js
@@ -7,9 +7,10 @@ if (!workingDir) {
 }
 
 if (!fs.existsSync(path.join(workingDir, 'android'))) {
-  throw new Error(
+  console.warn(
     'cannot install android-js-engine library: @capacitor/android not installed, or in wrong parent directory.',
   );
+  return;
 }
 
 const releaseAARPath = path.join(

--- a/packages/capacitor-plugin/scripts/install_libs.js
+++ b/packages/capacitor-plugin/scripts/install_libs.js
@@ -1,24 +1,29 @@
-const fs = require("fs");
+const fs = require('fs');
 const path = require('path');
 
 let workingDir = process.env.INIT_CWD;
 if (!workingDir) {
-    workingDir = ".";
+  workingDir = '.';
 }
 
-if (!fs.existsSync(path.join(workingDir, "android"))) {
-    throw new Error("cannot install android-js-engine library: @capacitor/android not installed, or in wrong parent directory.");
+if (!fs.existsSync(path.join(workingDir, 'android'))) {
+  throw new Error(
+    'cannot install android-js-engine library: @capacitor/android not installed, or in wrong parent directory.',
+  );
 }
 
-const releaseAARPath = path.join("android/src/main/libs/android-js-engine-release.aar");
+const releaseAARPath = path.join(
+  'android/src/main/libs/android-js-engine-release.aar',
+);
 
-const fullPath = path.join(workingDir, "android/app/libs")
+const fullPath = path.join(workingDir, 'android/app/libs');
 if (!fs.existsSync(fullPath)) {
-    fs.mkdirSync(fullPath);
+  fs.mkdirSync(fullPath);
 }
 
-fs.copyFileSync(releaseAARPath, path.join(fullPath, "android-js-engine-release.aar"))
+fs.copyFileSync(
+  releaseAARPath,
+  path.join(fullPath, 'android-js-engine-release.aar'),
+);
 
-console.log(`copied android-js-engine-release.aar to ${fullPath}`)
-
-
+console.log(`copied android-js-engine-release.aar to ${fullPath}`);

--- a/packages/capacitor-plugin/scripts/install_libs.js
+++ b/packages/capacitor-plugin/scripts/install_libs.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require('path');
+
+console.log(process.env.INIT_CWD);
+
+let workingDir = process.env.INIT_CWD;
+if (!workingDir) {
+    workingDir = ".";
+}
+
+if (!fs.existsSync(path.join(workingDir, "android"))) {
+    throw new Error("cannot install android-js-engine library, not in correct parent directory.");
+}
+
+const releaseAARPath = path.join("android/src/main/libs/android-js-engine-release.aar");
+
+const fullPath = path.join(workingDir, "android/app/libs")
+fs.mkdirSync(fullPath);
+fs.copyFileSync(releaseAARPath, path.join(fullPath, "android-js-engine-release.aar"))
+
+console.log(`copied android-js-engine-release.aar to ${fullPath}`)
+
+

--- a/packages/capacitor-plugin/scripts/install_libs.js
+++ b/packages/capacitor-plugin/scripts/install_libs.js
@@ -1,8 +1,6 @@
 const fs = require("fs");
 const path = require('path');
 
-console.log(process.env.INIT_CWD);
-
 let workingDir = process.env.INIT_CWD;
 if (!workingDir) {
     workingDir = ".";
@@ -15,7 +13,10 @@ if (!fs.existsSync(path.join(workingDir, "android"))) {
 const releaseAARPath = path.join("android/src/main/libs/android-js-engine-release.aar");
 
 const fullPath = path.join(workingDir, "android/app/libs")
-fs.mkdirSync(fullPath);
+if (!fs.existsSync(fullPath)) {
+    fs.mkdirSync(fullPath);
+}
+
 fs.copyFileSync(releaseAARPath, path.join(fullPath, "android-js-engine-release.aar"))
 
 console.log(`copied android-js-engine-release.aar to ${fullPath}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1(@capacitor/core@4.7.3)
       '@capacitor/background-runner':
-        specifier: ^4.0.0-rc.1
-        version: 4.0.0-rc.1(@capacitor/core@4.7.3)
+        specifier: ^1.0.0-rc.1
+        version: link:../../packages/capacitor-plugin
       '@capacitor/core':
         specifier: ^4.7.3
         version: 4.7.3
@@ -1659,15 +1659,6 @@ packages:
     resolution: {integrity: sha512-frPft9TMJL70jWq5jmxwGSBddZVvsWxX5Agj2i19WJerk37aTgljB05HRr/YLg6mF1G/NIXmmFJZDY8MEgirDg==}
     peerDependencies:
       '@capacitor/core': ^4.0.0
-    dependencies:
-      '@capacitor/core': 4.7.3
-    dev: false
-
-  /@capacitor/background-runner@4.0.0-rc.1(@capacitor/core@4.7.3):
-    resolution: {integrity: sha512-ObDNIYgll6+8RJaChkoX70SBUgmxa0TMXNWagT45hvfKPvx/BmTbn6ChFSwYVxCGteZiC4PtzdmidWMCHqh9hw==}
-    requiresBuild: true
-    peerDependencies:
-      '@capacitor/core': ^5.0.0
     dependencies:
       '@capacitor/core': 4.7.3
     dev: false


### PR DESCRIPTION
This PR fixes the package `postinstall` script on Windows.

closes: https://github.com/ionic-team/capacitor-background-runner/issues/9