### PR TITLE
fix: setting JavaVersion to 17

### DIFF
--- a/apps/example-app/android/app/capacitor.build.gradle
+++ b/apps/example-app/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
   }
 }
 

--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -43,8 +43,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
the minimum version required is JAVA 17, but the build.gradle files indicate 11, which is a problem for builders

closes: https://github.com/ionic-team/capacitor-background-runner/issues/15