### PR TITLE
docs (iOS): adding import statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ If you will be making use of Geolocation or Push Notifications, enable `Location
 
 After enabling the Background Modes capability, add the following to your app's `AppDelegate.swift`:
 
+At the top of the file, under `import Capacitor` add:
+```swift
+import CapacitorBackgroundRunner
+```
+
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 

--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -25,6 +25,11 @@ If you will be making use of Geolocation or Push Notifications, enable `Location
 
 After enabling the Background Modes capability, add the following to your app's `AppDelegate.swift`:
 
+At the top of the file, under `import Capacitor` add:
+```swift
+import CapacitorBackgroundRunner
+```
+
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 


### PR DESCRIPTION
Update the docs to mention adding the plugin import statement

closes: https://github.com/ionic-team/capacitor-background-runner/issues/34