### PR TITLE
bugfix: correct the CapacitorGeolocation typescript definitions

### DIFF
--- a/packages/capacitor-plugin/src/apis.ts
+++ b/packages/capacitor-plugin/src/apis.ts
@@ -253,7 +253,7 @@ export interface CapacitorGeolocation {
    * Get the device's last known location
    * @since 1.0.0
    */
-  getCurrentLocation: () => GetCurrentPositionResult;
+  getCurrentPosition: () => GetCurrentPositionResult;
 }
 
 /**


### PR DESCRIPTION
The Swift and Kotlin logic exposes `CapacitorGeolocation.getCurrentPosition()`, but the Typescript definitions specify `CapacitorGeolocation.getCurrentLocation()`.