### PR TITLE
fix(android): registering WorkRequest on handleOnPause

### DIFF
--- a/.changeset/tricky-stingrays-roll.md
+++ b/.changeset/tricky-stingrays-roll.md
@@ -1,0 +1,5 @@
+---
+"@capacitor/background-runner": minor
+---
+
+(Android): Fixing issue that disabled `appStateChange` events

--- a/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/BackgroundRunnerPlugin.kt
+++ b/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/BackgroundRunnerPlugin.kt
@@ -35,16 +35,15 @@ class BackgroundRunnerPlugin: Plugin() {
         const val NOTIFICATIONS = "notifications"
     }
 
+    override fun handleOnPause() {
+        super.handleOnPause()
+        Log.d("Background Runner", "registering runner workers")
+        impl?.scheduleBackgroundTask(this.context)
+    }
+
     override fun load() {
         super.load()
         impl = BackgroundRunner.getInstance(this.context)
-
-        bridge.app.setStatusChangeListener {
-            if (!it) {
-                Log.d("Background Runner", "registering runner workers")
-                impl?.scheduleBackgroundTask(this.context)
-            }
-        }
     }
 
     @PluginMethod

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -42,7 +42,7 @@
     "docgen-api": "docgen --api CapacitorAPI --output-readme API.md --output-json dist/docs-api.json && node ./scripts/combine_docs.js",
     "build-sdk": "./scripts/build-native-sdks.sh",
     "build": "npm run clean && npm run docgen && npm run docgen-api && tsc && rollup -c rollup.config.js && npm run build-sdk && ./scripts/copy-native-sdks.sh && npm pack && mv ./capacitor-background-runner-*.tgz ../../ && ./scripts/copy-readme.sh",
-    "pack": "npm run build && && ./scripts/copy-native-sdks.sh && npm pack && mv ./capacitor-background-runner-*.tgz ../../",
+    "pack": "npm run build && ./scripts/copy-native-sdks.sh && npm pack && mv ./capacitor-background-runner-*.tgz ../../",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
This PR fixes an issue that disabled `appStateChange` events on Android.

closes: https://github.com/ionic-team/capacitor-background-runner/issues/78