### PR TITLE
fix(iOS): Removing runloop thread

### DIFF
--- a/.changeset/funny-bulldogs-own.md
+++ b/.changeset/funny-bulldogs-own.md
@@ -1,0 +1,6 @@
+---
+"@capacitor/background-runner": patch
+"ios-engine": patch
+---
+
+(iOS): Removing unnecessary run loop thread causing spike in CPU while the app was in the foreground

--- a/packages/capacitor-plugin/ios/Plugin/BackgroundRunner.swift
+++ b/packages/capacitor-plugin/ios/Plugin/BackgroundRunner.swift
@@ -11,8 +11,7 @@ public class BackgroundRunner {
 
     public init() {
         do {
-            config = try self.loadRunnerConfig()
-            runner.start()
+            config = try self.loadRunnerConfig()            
         } catch {
             print("could not initialize BackgroundRunner: \(error)")
         }

--- a/packages/ios-engine/Sources/RunnerEngine/Runner.swift
+++ b/packages/ios-engine/Sources/RunnerEngine/Runner.swift
@@ -15,36 +15,4 @@ public class Runner {
     func createContext(name: String) throws -> Context {
         return try Context(vm: machine, contextName: name, runLoop: runLoop)
     }
-
-    func start() {
-        thread = Thread { [weak self] in
-            defer {
-                Thread.exit()
-            }
-
-            guard let self = self else { return }
-            guard let thread = self.thread else { return }
-
-            while !thread.isCancelled {
-                self.runLoop.run(mode: .default, before: .distantFuture)
-            }
-        }
-
-        thread?.qualityOfService = .userInitiated
-        thread?.start()
-    }
-
-    func stop() {
-        guard let thread = self.thread else {
-            return
-        }
-
-        thread.cancel()
-        
-        while !thread.isFinished {
-            Thread.sleep(forTimeInterval: 0.05)
-        }
-
-        self.thread = nil
-    }
 }

--- a/packages/ios-engine/Tests/RunnerEngineTests/RunnerTests.swift
+++ b/packages/ios-engine/Tests/RunnerEngineTests/RunnerTests.swift
@@ -3,25 +3,8 @@ import XCTest
 @testable import RunnerEngine
 
 final class RunnerTests: XCTestCase {
-    func testRunnerCreateDestroy() {
-        let runner = Runner()
-        runner.start()
-
-        runner.stop()
-    }
-
-    func testContextCreateDestroy() throws {
-        let runner = Runner()
-        runner.start()
-
-        _ = try runner.createContext(name: "io.ionic.android_js_engine")
-
-        runner.stop()
-    }
-
     func testMultipleContexts() throws {
         let runner = Runner()
-        runner.start()
 
         var calls = 0
         let count = Int.random(in: 20..<40)
@@ -43,8 +26,6 @@ final class RunnerTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 5)
-
-        runner.stop()
     }
 
 }


### PR DESCRIPTION
Removing unnecessary run loop thread causing spike in CPU while the app was in the foreground