### PR TITLE
refactor!: fix typo in CapacitorWatch

### DIFF
--- a/.changeset/modern-panthers-thank.md
+++ b/.changeset/modern-panthers-thank.md
@@ -1,0 +1,5 @@
+---
+"@capacitor/background-runner": major
+---
+
+Fixing typo in CapacitorWatch interface name

--- a/README.md
+++ b/README.md
@@ -492,21 +492,21 @@ Get access to device location information.
 | **`heading`**          | <code>number \| null</code> | The heading the user is facing (if available)                                                                         | 1.0.0 |
 
 
-#### CapcacitorWatch
+#### CapacitorWatch
 
 Interact with a watch paired with this app
 
 sendMessage, transferUserInfo and updateApplicationContext are raw routes to the WCSession delegate methods, but have no effects currently in a CapactiorWatch Watch application.
 They could be used if a native watch app is developed as a companion app to a Capacitor app
 
-| Prop                           | Type                                                                     | Description                                                                                                                                                 |
-| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a CapacitorWatch watch app                              |
-| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a CapacitorWatch watch app                       |
-| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a CapacitorWatch watch app |
-| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                            |
-| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                           |
-| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                          |
+| Prop                           | Type                                                                     | Description                                                                                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                              |
+| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                       |
+| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app |
+| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                                                          |
+| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                                                         |
+| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                                                        |
 
 
 </capacitor-api-docs>

--- a/packages/capacitor-plugin/API.md
+++ b/packages/capacitor-plugin/API.md
@@ -97,20 +97,20 @@ Get access to device location information.
 | **`heading`**          | <code>number \| null</code> | The heading the user is facing (if available)                                                                         | 1.0.0 |
 
 
-#### CapcacitorWatch
+#### CapacitorWatch
 
 Interact with a watch paired with this app
 
 sendMessage, transferUserInfo and updateApplicationContext are raw routes to the WCSession delegate methods, but have no effects currently in a CapactiorWatch Watch application.
 They could be used if a native watch app is developed as a companion app to a Capacitor app
 
-| Prop                           | Type                                                                     | Description                                                                                                                                                 |
-| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a CapacitorWatch watch app                              |
-| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a CapacitorWatch watch app                       |
-| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a CapacitorWatch watch app |
-| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                            |
-| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                           |
-| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                          |
+| Prop                           | Type                                                                     | Description                                                                                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                              |
+| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                       |
+| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app |
+| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                                                          |
+| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                                                         |
+| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                                                        |
 
 </docgen-api>

--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -492,21 +492,21 @@ Get access to device location information.
 | **`heading`**          | <code>number \| null</code> | The heading the user is facing (if available)                                                                         | 1.0.0 |
 
 
-#### CapcacitorWatch
+#### CapacitorWatch
 
 Interact with a watch paired with this app
 
 sendMessage, transferUserInfo and updateApplicationContext are raw routes to the WCSession delegate methods, but have no effects currently in a CapactiorWatch Watch application.
 They could be used if a native watch app is developed as a companion app to a Capacitor app
 
-| Prop                           | Type                                                                     | Description                                                                                                                                                 |
-| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a CapacitorWatch watch app                              |
-| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a CapacitorWatch watch app                       |
-| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a CapacitorWatch watch app |
-| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                            |
-| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                           |
-| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                          |
+| Prop                           | Type                                                                     | Description                                                                                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`sendMessage`**              | <code>(options: []) =&gt; void</code>                                    | Sends a message to the watch with the sendMessage() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                              |
+| **`transferUserInfo`**         | <code>(options: []) =&gt; void</code>                                    | Sends information to the watch with the transferUserInfo() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app                       |
+| **`updateApplicationContext`** | <code>(options: []) =&gt; void</code>                                    | Updates the application context on the watch with the updateApplicationContext() WCSession delegate method This has no effect on a <a href="#capacitorwatch">CapacitorWatch</a> watch app |
+| **`isReachable`**              | <code>boolean</code>                                                     | Checks to see if the compaion watch is reachable                                                                                                                                          |
+| **`updateWatchUI`**            | <code>(options: { watchUI: string; }) =&gt; void</code>                  | Replaces the current UI on the watch with what is specified here.                                                                                                                         |
+| **`updateWatchData`**          | <code>(options: { data: { [key: string]: string; }; }) =&gt; void</code> | Updates the data the watch is using to display variables in text and button fields                                                                                                        |
 
 
 </capacitor-api-docs>

--- a/packages/capacitor-plugin/src/apis.ts
+++ b/packages/capacitor-plugin/src/apis.ts
@@ -323,7 +323,7 @@ export interface CapacitorNotifications {
  * sendMessage, transferUserInfo and updateApplicationContext are raw routes to the WCSession delegate methods, but have no effects currently in a CapactiorWatch Watch application.
  * They could be used if a native watch app is developed as a companion app to a Capacitor app
  */
-export interface CapcacitorWatch {
+export interface CapacitorWatch {
   /**
    * Sends a message to the watch with the sendMessage() WCSession delegate method
    *
@@ -365,5 +365,5 @@ export interface CapacitorAPI {
   CapacitorKV: CapacitorKV;
   CapacitorNotifications: CapacitorNotifications;
   CapacitorGeolocation: CapacitorGeolocation;
-  CapacitorWatch: CapcacitorWatch;
+  CapacitorWatch: CapacitorWatch;
 }


### PR DESCRIPTION
Marking the PR as breaking since it changes the interface name