### PR TITLE
docs(contributing): Use pnpm to install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This guide provides instructions for contributing to this Capacitor plugin.
 1. Install the dependencies.
 
     ```shell
-    npm install
+    pnpm install
     ```
 
 1. Install SwiftLint if you're on macOS.


### PR DESCRIPTION
npm install fails and there are pnpm files, so I think the plugin uses pnpm instead of npm