### PR TITLE
fix(iOS): Fixing task repeat mechanism for iOS

### DIFF
--- a/.changeset/orange-vans-hide.md
+++ b/.changeset/orange-vans-hide.md
@@ -1,0 +1,5 @@
+---
+"@capacitor/background-runner": minor
+---
+
+(iOS) Fixing task repeat functionality

--- a/packages/capacitor-plugin/ios/Plugin/BackgroundRunner.swift
+++ b/packages/capacitor-plugin/ios/Plugin/BackgroundRunner.swift
@@ -52,6 +52,10 @@ public class BackgroundRunner {
                 _ = try BackgroundRunner.shared.execute(config: config)
 
                 task.setTaskCompleted(success: true)
+
+                if config.repeats {
+                    try self.scheduleBackgroundTasks()
+                }
             } catch {
                 print("background task error: \(error)")
                 task.setTaskCompleted(success: false)

--- a/packages/capacitor-plugin/ios/Plugin/RunnerConfig.swift
+++ b/packages/capacitor-plugin/ios/Plugin/RunnerConfig.swift
@@ -6,7 +6,7 @@ public struct RunnerConfig {
     let src: String
     var autoSchedule: Bool
     var event: String
-    let repeats: Bool?
+    let repeats: Bool
     let enableWatchConnectivity: Bool
 
     let interval: Int?
@@ -28,7 +28,7 @@ public struct RunnerConfig {
         self.label = label
         self.src = src
         self.event = event
-        self.repeats = repeats
+        self.repeats = repeats ?? false
         self.interval = interval
         self.autoSchedule = autoStart ?? false
         self.enableWatchConnectivity = jsObject["enableWatchConnectivity"] as? Bool ?? false


### PR DESCRIPTION
I was trying to get a repeating iOS background task working, but could not get it working. I only get background task on iOS working once. Took a look at the code and it seems a repeat mechanism for iOS has not been implemented. This change takes care to reschedule a task after it ran and is configured to repeat.