### PR TITLE
chore(ci): Use Xcode 26

### DIFF
--- a/.github/workflows/reusable_unit-tests.yml
+++ b/.github/workflows/reusable_unit-tests.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     steps:
+      - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0


### PR DESCRIPTION
https://github.com/ionic-team/capacitor-background-runner/pull/149 didn't fix the unit tests because `macos-15` use Xcode 16.4 by default, so it doesn't find iOS 26 simulators neither, make it use Xcode 26 (also because Capacitor 8 doesn't support Xcode 16)