### PR TITLE
fix(android): AGP 9.0 no longer supports `proguard-android.txt`

### DIFF
--- a/.changeset/khaki-carpets-win.md
+++ b/.changeset/khaki-carpets-win.md
@@ -1,0 +1,5 @@
+---
+"@capacitor/background-runner": minor
+---
+
+(Android): Replaces the default proguard file proguard-android.txt with proguard-android-optimize.txt which allows proguard optimizations

--- a/packages/capacitor-plugin/android/build.gradle
+++ b/packages/capacitor-plugin/android/build.gradle
@@ -37,7 +37,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
This change replaces the default proguard file `proguard-android.txt` with `proguard-android-optimize.txt` which allows proguard optimizations.

x-ref: https://github.com/ionic-team/capacitor/pull/8315 & https://github.com/ionic-team/capacitor-plugins/pull/2468