### PR TITLE
chore(ci): download iOS simulators and test on iPhone 17

### DIFF
--- a/.github/workflows/reusable_unit-tests.yml
+++ b/.github/workflows/reusable_unit-tests.yml
@@ -12,6 +12,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - run: sudo xcode-select --switch /Applications/Xcode_26.0.app
+      - run: xcrun simctl list > /dev/null
+      - run: xcodebuild -downloadPlatform iOS
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapacitorBackgroundRunner -destination generic/platform=iOS && xcodebuild test -scheme CapacitorBackgroundRunner -destination 'platform=iOS Simulator,OS=26.0.1,name=iPhone 16 Pro'",
+    "verify:ios": "xcodebuild -scheme CapacitorBackgroundRunner -destination generic/platform=iOS && xcodebuild test -scheme CapacitorBackgroundRunner -destination 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17 Pro'",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",


### PR DESCRIPTION
github no longer adds simulators when using xcode 26, so download them

also test on iPhone 17 as 16 won't be downloaded anymore