### PR TITLE
fix(android)!: allow offline background execution

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/BackgroundRunner.kt
+++ b/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/BackgroundRunner.kt
@@ -5,7 +5,6 @@ import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
@@ -62,9 +61,7 @@ class BackgroundRunner(context: android.content.Context) {
             .putString("event", config.event)
             .build()
 
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
+        val constraints = Constraints.Builder().build()
 
         if (!config.repeats) {
             val work = OneTimeWorkRequest.Builder(RunnerWorker::class.java)


### PR DESCRIPTION
## Description
There is no need to blocking background runner from starting when there is no internet connection or when the app has no internet permission. There is tons of use cases for bg runner without the internet. 
If there is no internet, the task invoked by the runner should handle it, not the runner. 

This is potentially breaking change for low quality tasks. 

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [x] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Issue link
https://github.com/ionic-team/capacitor-background-runner/issues/158

## Rationale / Problems Fixed
As in the description. My app is fully offline, so I removed the internet permission and background runner failed to run. 

## Tests or Reproductions
With any project using the background runner, either disable the internet or remove the internet permission and see if it still runs. Before the change, task was never invoked. 

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

