### PR TITLE
fix(local-notifications)!: read config from LocalNotifications plugin object

### DIFF
--- a/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notification.kt
+++ b/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notification.kt
@@ -5,7 +5,6 @@ import com.getcapacitor.plugin.util.AssetUtil
 import org.json.JSONObject
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.TimeZone
 
 @SuppressLint("SimpleDateFormat")
 class Notification(jsonObject: JSONObject) {
@@ -26,7 +25,7 @@ class Notification(jsonObject: JSONObject) {
     var groupSummary: String? = null
     var channelId: String? = null
 
-    private val jsDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private val jsDateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
 
     init {
         id = jsonObject.optInt("id", -1)
@@ -35,7 +34,7 @@ class Notification(jsonObject: JSONObject) {
         smallIcon = jsonObject.optString("smallIcon", "")
         ongoing = jsonObject.optBoolean("ongoing", false)
         autoCancel = jsonObject.optBoolean("autoCancel", false)
-        actionTypeId = jsonObject.optString("actionTypeId", null)
+        actionTypeId = jsonObject.optString("actionTypeId")
 
         val scheduleDateString = jsonObject.optString("scheduleAt", "")
         if (scheduleDateString.isNotEmpty()) {

--- a/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notifications.kt
+++ b/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notifications.kt
@@ -24,7 +24,6 @@ import org.json.JSONObject
 class Notifications(context: Context) : NotificationsAPI {
     private val manager: NotificationManagerCompat
     private val context: Context
-    private val capConfig: CapConfig
     private val config: PluginConfig
 
     var defaultSmallIconID = AssetUtil.RESOURCE_ID_ZERO_VALUE
@@ -33,8 +32,7 @@ class Notifications(context: Context) : NotificationsAPI {
     init {
         this.context = context
         this.manager = NotificationManagerCompat.from(context)
-        this.capConfig = CapConfig.loadDefault(context)
-        this.config = capConfig.getPluginConfiguration("LocalNotifications")
+        this.config = CapConfig.loadDefault(context).getPluginConfiguration("LocalNotifications")
         this.createNotificationChannel()
         this.createBadgeNotificationChannel()
     }

--- a/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notifications.kt
+++ b/packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notifications.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.getcapacitor.CapConfig
+import com.getcapacitor.PluginConfig
 import com.getcapacitor.plugin.util.AssetUtil
 import io.ionic.android_js_engine.capacitor_api.NotificationsAPI
 import org.json.JSONArray
@@ -23,7 +24,8 @@ import org.json.JSONObject
 class Notifications(context: Context) : NotificationsAPI {
     private val manager: NotificationManagerCompat
     private val context: Context
-    private val config: CapConfig
+    private val capConfig: CapConfig
+    private val config: PluginConfig
 
     var defaultSmallIconID = AssetUtil.RESOURCE_ID_ZERO_VALUE
     var defaultSoundID = AssetUtil.RESOURCE_ID_ZERO_VALUE
@@ -31,8 +33,8 @@ class Notifications(context: Context) : NotificationsAPI {
     init {
         this.context = context
         this.manager = NotificationManagerCompat.from(context)
-        this.config = CapConfig.loadDefault(context)
-
+        this.capConfig = CapConfig.loadDefault(context)
+        this.config = capConfig.getPluginConfiguration("LocalNotifications")
         this.createNotificationChannel()
         this.createBadgeNotificationChannel()
     }


### PR DESCRIPTION

## Description
fix deprecation warnings on CapConfig getString by replacing it with PluginConfig and use LocalNotifications objects to get the values from there.

Technically is a breaking change since before the change is expecting the configuration on the root of the capacitor config object, but it's not really documented and it's a bug as there is no accessors for those values (that should be in Capacitor itself, not in the plugin). Plugins should declare their own configuration, not expect them to be in Capacitor.

Also fixed some code warnings in packages/capacitor-plugin/android/src/main/java/io/ionic/backgroundrunner/plugin/api/Notification.kt

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [x] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
CapConfig.getString is deprecated, replace CapConfig with PluginConfig as it's not deprecated and it's what should be using.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [x] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
